### PR TITLE
Add kadi/events3.db3, remove eng_archive in favor of cheta_sync

### DIFF
--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -20,6 +20,7 @@ file_sync:
     - cmds.h5
     - cmds.pkl
     - events.db3
+    - events3.db3
 
   Ska.tdb:
     - p014
@@ -53,49 +54,3 @@ file_sync:
   # ska_testr test data
   ska_testr:
     - test_loads
-
-  # Minimal set of eng-archive files for doing ACA and ACIS load review
-  eng_archive:
-    - data/orbitephem0/colnames.pickle
-    - data/orbitephem0/archfiles.db3
-    - data/orbitephem0/TIME.h5
-    - data/orbitephem0/ORBITEPHEM0_X.h5
-    - data/orbitephem0/ORBITEPHEM0_Y.h5
-    - data/orbitephem0/ORBITEPHEM0_Z.h5
-    - data/dp_pcad4/colnames.pickle
-    - data/dp_pcad4/5min/DP_ROLL.h5
-    - data/dp_pcad4/5min/DP_PITCH.h5
-    - data/pcad5eng/colnames.pickle
-    - data/pcad5eng/5min/AACCCDPT.h5
-    - data/pcad5eng/TIME.h5
-    - data/acisdeahk/colnames.pickle
-    - data/acisdeahk/5min/FPTEMP_11.h5
-    - data/acisdeahk/TIME.h5
-    - data/acis2eng/colnames.pickle
-    - data/acis2eng/5min/1DPAMZT.h5
-    - data/acis2eng/5min/1DEAMZT.h5
-    - data/acis2eng/5min/1PDEAAT.h5
-    - data/acis2eng/5min/1DAHTBON.h5
-    - data/simcoor/colnames.pickle
-    - data/simcoor/5min/SIM_Z.h5
-    - data/dp_acispow128/colnames.pickle
-    - data/dp_acispow128/5min/DP_DPA_POWER.h5
-    - data/pcad3eng/5min/AOECLIPS.h5
-    - data/pcad3eng/colnames.pickle
-    - data/prop1eng/5min/PFTANK2T.h5
-    - data/prop1eng/colnames.pickle
-
-################################################################################
-# Ska telemetry archive MSIDs or content types to sync
-#
-# NOTE: currently not supported.
-################################################################################
-eng_archive:
-  full:
-    - tephin
-
-  daily:
-    - '*'  # sync everything in the daily archives
-
-  5min:
-    - 'thm?eng'


### PR DESCRIPTION
The minimal `eng_archive` sync config is probably still useful, but does not belong in the default config because doing this rsync will corrupt a cheta-sync'd archive.  Not clear where to put this file list.