### PR TITLE
Add chandra_models for sync

### DIFF
--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -54,3 +54,6 @@ file_sync:
   # ska_testr test data
   ska_testr:
     - test_loads
+
+  chandra_models:
+    - .


### PR DESCRIPTION
## Description

This is a companion to https://github.com/sot/xija/pull/96 which makes `$SKA/data/chandra_models` part of the standard sync data.  That directory is a clone of the corresponding GitHub repo and the version on HEAD will be managed by a Ska admin by a configuration process (to be defined). For now I just made it be a clone of the latest chandra_models.

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows
- [x] Functional testing

### Functional testing

Made a local version of the chandra_models repo in $SKA/data/chandra_models, then purposely made a random commit (to simulate the user doing this). Then I ran:
```
python -m ska_sync.main --install --force
python -m ska_sync.main
# follow instructions to run the rsync command
```
I then checked that the chandra_models repo was updated and looked good (checked out and clean at the 3.32 tag).
