### PR TITLE
Use getpass.getuser() instead of USER env var

### DIFF
--- a/ska_sync/main.py
+++ b/ska_sync/main.py
@@ -8,6 +8,7 @@ Arguments
 =========
 """
 import os
+import getpass
 
 import yaml
 
@@ -82,7 +83,7 @@ def main():
     print('Loaded config from {}'.format(config_path))
 
     # Remote user name
-    user = opt.user or config.get('user') or os.environ['USER']
+    user = opt.user or config.get('user') or getpass.getuser()
 
     file_sync(config['file_sync'], user, config['host'])
 


### PR DESCRIPTION
## Description

On Mac the `USER` environment variable is not defined normally. The multiplatform way to get the user is with `getpass.getuser()`.

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

Ran on my Mac and it worked.