### PR TITLE
Update Ska.tdb to p015 and add cdb directory

### DIFF
--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -23,7 +23,8 @@ file_sync:
     - events3.db3
 
   Ska.tdb:
-    - p014
+    - p015
+    - cdb
 
   cmd_states:
     - cmd_states.h5


### PR DESCRIPTION
## Description

I populated the `/proj/sot/ska/data/Ska.tdb/p015` directory on HEAD with the final Rev. 5 released version. I also added a new subdirectory `cdb` that includes `p010` of the commands database. This currently uses the CSV files created by @matthewdahmer .

The Ska.tdb code doesn't actually do anything with the CDB files, but at least they are there now. This update includes them in standard syncing.

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

I updated my own $ska/ska_sync_config like this and resynced and got the expected files.