### PR TITLE
Add mica obspars

### DIFF
--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -41,6 +41,7 @@ file_sync:
   mica:
     - archive/aca_dark
     - archive/starcheck/starcheck.db3
+    - archive/obspar/archfiles.db3
 
   # ACA guide star statistics
   # http://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/mica/guide_stats.html


### PR DESCRIPTION
## Description

Add the mica obspars archfiles.db3 to allow laptop access to obspars.

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing: works locally for me
