### PR TITLE
Changes to the default ska_sync_config

### DIFF
--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -19,11 +19,14 @@ file_sync:
   kadi:
     - cmds.h5
     - cmds.pkl
+    - cmds2.h5
+    - cmds2.pkl
     - events.db3
     - events3.db3
 
+  # Telemetry database, assuming fewer than 99 versions total
   Ska.tdb:
-    - p015
+    - p0??
     - cdb
 
   cmd_states:
@@ -33,7 +36,6 @@ file_sync:
   # AGASC star catalog data.  Note that this is about a gigabyte.
   agasc:  # ~2 Gb
     - miniagasc.h5
-    - miniagasc_1p7.h5
     - proseco_agasc_1p7.h5
     - agasc_supplement.h5
 

--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -26,8 +26,7 @@ file_sync:
 
   # Telemetry database, assuming fewer than 99 versions total
   Ska.tdb:
-    - p0??
-    - cdb
+    - .
 
   cmd_states:
     - cmd_states.h5


### PR DESCRIPTION
## Description

This makes a few changes to the default sync config file:
- Add v2 commands files
- Sync everything in Ska.TDB (all TDB versions and the CDB)
- Stop syncing miniagasc_1p7.h5 since miniagasc.h5 is a real file now.

## Testing

- [n/a] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

Used this myself for sync and it worked as expected.