### PR TITLE
Stop syncing old ska2 kadi events and old cmd_states

### DIFF
--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -28,7 +28,6 @@ file_sync:
     - .
 
   cmd_states:
-    - cmd_states.h5
     - cmd_states.db3
 
   # AGASC star catalog data.  Note that this is about a gigabyte.

--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -21,7 +21,6 @@ file_sync:
     - cmds.pkl
     - cmds2.h5
     - cmds2.pkl
-    - events.db3
     - events3.db3
 
   # Telemetry database, assuming fewer than 99 versions total


### PR DESCRIPTION
## Description

Stop syncing old ska2 kadi events and old cmd_states
