### PR TITLE
Sync ACIS tables

### DIFF
--- a/ska_sync/ska_sync_config
+++ b/ska_sync/ska_sync_config
@@ -59,3 +59,6 @@ file_sync:
 
   chandra_models:
     - .
+    
+  acis_tables:
+    - .


### PR DESCRIPTION
## Description

Add the `acis_tables` directory, which appropriately enough contains the ACIS tables, to `ska_sync`.

## Interface impacts

Adds two new files totaling about 2.5 Mb to the standard Ska data in `$SKA/data/acis_tables`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

- [x] @taldcroft installed the new sync config and confirmed that the ACIS tables get synced
- [x] @jzuhone installed the new sync config and confirmed that the ACIS tables get synced, verified that they can be read in the same way as before